### PR TITLE
Integrate Quizdown quizzes

### DIFF
--- a/docs/arrays.rst
+++ b/docs/arrays.rst
@@ -197,3 +197,5 @@ Key Rules and Limitations
 
 Arrays are a critical part of programming in Arduino, enabling efficient
 and organized management of related data.
+
+.. quizdown:: quizzes/arrays_quiz.md

--- a/docs/arrays.rst
+++ b/docs/arrays.rst
@@ -171,8 +171,9 @@ Key Rules and Limitations
   .. code:: cpp
 
      int numbers[3] = {1, 2, 3};
-     int invalidAccess = numbers[5]; // Not good! This array only has 3 elements.
+    int invalidAccess = numbers[5]; // Not good! This array only has 3 elements.
 
+.. quizdown:: quizzes/arrays_quiz.md
 
 .. note::
 
@@ -197,5 +198,3 @@ Key Rules and Limitations
 
 Arrays are a critical part of programming in Arduino, enabling efficient
 and organized management of related data.
-
-.. quizdown:: quizzes/arrays_quiz.md

--- a/docs/basic_arduino_structure.rst
+++ b/docs/basic_arduino_structure.rst
@@ -127,3 +127,5 @@ Best Practices for Commenting
 By incorporating thoughtful comments into your code, you'll create
 programs that are not only functional but also accessible and easy to
 manage.
+
+.. quizdown:: quizzes/basic_structure_quiz.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,25 @@ release = "1.0.0"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["whole_code_block"]
+extensions = [
+    "whole_code_block",
+    "sphinxcontrib.quizdown",
+]
+
+# -- Quizdown integration -------------------------------------------------
+html_css_files = [
+    "whole_code_block.css",
+]
+
+# Global configuration for sphinxcontrib-quizdown
+quizdown_config = {
+    "start_on_load": True,
+    "shuffle_answers": True,
+    "shuffle_questions": False,
+    "primary_color": "#FF851B",
+    "secondary_color": "#DDDDDD",
+    "text_color": "black",
+}
 
 templates_path = ["_templates"]
 
@@ -65,7 +83,6 @@ html_title = "The Arduino Guide"
 # A shorter title for the navigation bar.  Default is the same as html_title.
 html_short_title = "Arduino Guide"
 
-html_css_files = ["whole_code_block.css"]
 
 html_favicon = "_static/favicon.ico"
 

--- a/docs/control_structures.rst
+++ b/docs/control_structures.rst
@@ -293,3 +293,5 @@ it down by splitting the ``!`` operator into a separate variable:
     if (notGreaterThan30) {
         // Code to run when the temperature is not above 30
     }
+
+.. quizdown:: quizzes/control_structures_quiz.md

--- a/docs/first_arduino_program.rst
+++ b/docs/first_arduino_program.rst
@@ -141,3 +141,5 @@ that we printed in our code.
 Congrats! You've just written and run your first Arduino program. This
 is a simple example, but it's a great starting point for learning more
 about programming and working with Arduino.
+
+.. quizdown:: quizzes/first_program_quiz.md

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -508,3 +508,6 @@ How Are User-Defined Functions Different from Built-In Functions?
   organize and encapsulate tasks specific to your program. They allow
   you to implement behaviors that are not directly available through
   built-in functions.
+
+.. quizdown:: quizzes/functions_quiz.md
+

--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -143,3 +143,5 @@ connect the servo motor to a specific pin on the Arduino board.
 
 To see the use of the ``Servo`` library's methods, see :ref:`Servo Motor
 Control <servo_motor_control>`.
+
+.. quizdown:: quizzes/libraries_quiz.md

--- a/docs/loops.rst
+++ b/docs/loops.rst
@@ -463,6 +463,8 @@ You can use ``continue`` and ``break`` with **both** ``for`` and ``while``
 loops. These statements give you more control over the flow of your
 loops, allowing you to fine-tune your code based on specific conditions.
 
+.. quizdown:: quizzes/loops_quiz.md
+
 Loops vs. ``loop()``
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -511,8 +513,3 @@ Arduino programming.
          }
       }
 
-.. important::
-
-   Think of ``loop()`` as your program's big picture cycle, while ``for`` and ``while`` loops handle specific, smaller repetitions inside it.
-
-.. quizdown:: quizzes/loops_quiz.md

--- a/docs/loops.rst
+++ b/docs/loops.rst
@@ -514,3 +514,5 @@ Arduino programming.
 .. important::
 
    Think of ``loop()`` as your program's big picture cycle, while ``for`` and ``while`` loops handle specific, smaller repetitions inside it.
+
+.. quizdown:: quizzes/loops_quiz.md

--- a/docs/math.rst
+++ b/docs/math.rst
@@ -231,3 +231,5 @@ These shorthand operators are useful for updating variables in a single
 step, reducing the amount of code you need to write. You should use
 these operators when you want to increment, decrement, or modify a
 variable's value quickly and efficiently.
+
+.. quizdown:: quizzes/math_quiz.md

--- a/docs/quizzes/arrays_quiz.md
+++ b/docs/quizzes/arrays_quiz.md
@@ -1,0 +1,4 @@
+# How do you access the second element of an array named `values`?
+- [ ] values(1);
+- [x] values[1];
+- [ ] values<1>;

--- a/docs/quizzes/arrays_quiz.md
+++ b/docs/quizzes/arrays_quiz.md
@@ -5,6 +5,14 @@
     > Square brackets with index 1 retrieve the second element.
 1. [ ] values<1>;
 
+### Which line declares an array of five integers named `readings`?
+> Specify the type, then the name with a size in brackets.
+1. [ ] readings int[5];
+1. [x] int readings[5];
+    > Correct syntax uses `int readings[5];`.
+1. [ ] int[5] readings;
+1. [ ] array<int,5> readings;
+
 ### What index is used for the first element of an array?
 > Arrays in Arduino start counting from this number.
 1. [x] 0

--- a/docs/quizzes/arrays_quiz.md
+++ b/docs/quizzes/arrays_quiz.md
@@ -1,4 +1,13 @@
-# How do you access the second element of an array named `values`?
-- [ ] values(1);
-- [x] values[1];
-- [ ] values<1>;
+### How do you access the second element of an array named `values`?
+> Remember that C-style arrays are zero indexed.
+1. [ ] values(1);
+1. [x] values[1];
+    > Square brackets with index 1 retrieve the second element.
+1. [ ] values<1>;
+
+### What index is used for the first element of an array?
+> Arrays in Arduino start counting from this number.
+1. [x] 0
+    > Index 0 refers to the first element.
+1. [ ] 1
+1. [ ] It varies

--- a/docs/quizzes/basic_structure_quiz.md
+++ b/docs/quizzes/basic_structure_quiz.md
@@ -11,3 +11,19 @@
     > Both are required by the Arduino framework.
 - [ ] main()
 - [ ] start()
+
+### What does this sketch print to the Serial Monitor?
+```cpp
+void setup() {
+  Serial.begin(9600);
+  Serial.println("Hi");
+}
+
+void loop() {}
+```
+> `setup()` runs once before `loop()`.
+1. [ ] It prints nothing.
+1. [x] It prints "Hi" once.
+    > `Serial.println` in `setup()` executes a single time.
+1. [ ] It prints "Hi" repeatedly.
+1. [ ] It prints "HiHi".

--- a/docs/quizzes/basic_structure_quiz.md
+++ b/docs/quizzes/basic_structure_quiz.md
@@ -1,4 +1,13 @@
-# Which character begins a single-line comment in Arduino?
-- [x] //
-- [ ] /**
-- [ ] <!--
+### Which character begins a single-line comment in Arduino?
+1. [x] //
+    > Correct. Double slashes begin a comment.
+1. [ ] /**
+1. [ ] <!--
+
+### Which two functions must be present in every Arduino sketch?
+> These functions define what happens once and what repeats.
+- [x] setup()
+- [x] loop()
+    > Both are required by the Arduino framework.
+- [ ] main()
+- [ ] start()

--- a/docs/quizzes/basic_structure_quiz.md
+++ b/docs/quizzes/basic_structure_quiz.md
@@ -1,0 +1,4 @@
+# Which character begins a single-line comment in Arduino?
+- [x] //
+- [ ] /**
+- [ ] <!--

--- a/docs/quizzes/control_structures_quiz.md
+++ b/docs/quizzes/control_structures_quiz.md
@@ -1,0 +1,4 @@
+# Which operator represents logical AND in Arduino?
+- [ ] ||
+- [x] &&
+- [ ] !

--- a/docs/quizzes/control_structures_quiz.md
+++ b/docs/quizzes/control_structures_quiz.md
@@ -1,4 +1,12 @@
-# Which operator represents logical AND in Arduino?
-- [ ] ||
-- [x] &&
-- [ ] !
+### Which operator represents logical AND in Arduino?
+> This operator ensures both expressions are true.
+1. [ ] ||
+1. [x] &&
+    > `&&` returns true only if both sides are true.
+1. [ ] !
+
+### Which keyword begins a decision-making statement?
+1. [x] if
+    > `if` checks a condition before running code.
+1. [ ] loop
+1. [ ] goto

--- a/docs/quizzes/control_structures_quiz.md
+++ b/docs/quizzes/control_structures_quiz.md
@@ -10,3 +10,18 @@
     > `if` checks a condition before running code.
 1. [ ] loop
 1. [ ] goto
+
+### What will this code print when `x` is 3?
+```cpp
+int x = 3;
+if (x > 2) {
+  Serial.println("yes");
+} else {
+  Serial.println("no");
+}
+```
+> Evaluate the comparison `x > 2`.
+1. [x] yes
+    > 3 is greater than 2, so the `if` branch runs.
+1. [ ] no
+1. [ ] It prints nothing.

--- a/docs/quizzes/first_program_quiz.md
+++ b/docs/quizzes/first_program_quiz.md
@@ -1,0 +1,4 @@
+# Which function runs once at the start of your Arduino program?
+- [x] setup()
+- [ ] loop()
+- [ ] main()

--- a/docs/quizzes/first_program_quiz.md
+++ b/docs/quizzes/first_program_quiz.md
@@ -10,3 +10,18 @@
     > Setup configures hardware before looping.
 - [ ] Inside `loop()`
 - [ ] Outside of any function
+
+### What will the built-in LED do in this program?
+```cpp
+void setup() {
+  pinMode(LED_BUILTIN, OUTPUT);
+  digitalWrite(LED_BUILTIN, HIGH);
+}
+
+void loop() {}
+```
+> The LED is turned on once in `setup()`.
+1. [x] It turns on and stays on.
+    > `digitalWrite` sets the LED HIGH and `loop()` does nothing else.
+1. [ ] It blinks forever.
+1. [ ] It never turns on.

--- a/docs/quizzes/first_program_quiz.md
+++ b/docs/quizzes/first_program_quiz.md
@@ -1,4 +1,12 @@
-# Which function runs once at the start of your Arduino program?
-- [x] setup()
-- [ ] loop()
-- [ ] main()
+### Which function runs once at the start of your Arduino program?
+> This function is called before `loop()`.
+1. [x] setup()
+    > Correct. `setup()` runs a single time.
+1. [ ] loop()
+1. [ ] main()
+
+### Where should you set `pinMode()` calls?
+- [x] Inside `setup()`
+    > Setup configures hardware before looping.
+- [ ] Inside `loop()`
+- [ ] Outside of any function

--- a/docs/quizzes/functions_quiz.md
+++ b/docs/quizzes/functions_quiz.md
@@ -10,3 +10,11 @@
     > `return` stops the function and optionally sends data back.
 1. [ ] break
 1. [ ] continue
+
+### Which line correctly defines a function named `blink` that takes no parameters and returns nothing?
+> In Arduino, the return type comes first.
+1. [x] void blink() {}
+    > `void` indicates no return value.
+1. [ ] blink() void {}
+1. [ ] int blink(void);
+1. [ ] void blink;

--- a/docs/quizzes/functions_quiz.md
+++ b/docs/quizzes/functions_quiz.md
@@ -1,0 +1,4 @@
+# What does a function's return type specify?
+- [ ] The function's name
+- [x] The type of value it returns
+- [ ] The number of parameters

--- a/docs/quizzes/functions_quiz.md
+++ b/docs/quizzes/functions_quiz.md
@@ -1,4 +1,12 @@
-# What does a function's return type specify?
-- [ ] The function's name
-- [x] The type of value it returns
-- [ ] The number of parameters
+### What does a function's return type specify?
+> It appears before the function name.
+1. [ ] The function's name
+1. [x] The type of value it returns
+    > The return type tells callers what value will come back.
+1. [ ] The number of parameters
+
+### Which keyword exits a function and provides a value?
+1. [x] return
+    > `return` stops the function and optionally sends data back.
+1. [ ] break
+1. [ ] continue

--- a/docs/quizzes/libraries_quiz.md
+++ b/docs/quizzes/libraries_quiz.md
@@ -1,0 +1,4 @@
+# What keyword is used to include a library in your sketch?
+- [x] #include
+- [ ] import
+- [ ] using

--- a/docs/quizzes/libraries_quiz.md
+++ b/docs/quizzes/libraries_quiz.md
@@ -10,3 +10,10 @@
     > The Library Manager downloads and installs libraries.
 1. [ ] Serial Monitor
 1. [ ] Board Manager
+
+### Which statement adds the `Wire` library to your sketch?
+1. [x] #include <Wire.h>
+    > Angle brackets include standard libraries like Wire.
+1. [ ] import Wire
+1. [ ] include "Wire"
+1. [ ] using Wire;

--- a/docs/quizzes/libraries_quiz.md
+++ b/docs/quizzes/libraries_quiz.md
@@ -1,4 +1,12 @@
-# What keyword is used to include a library in your sketch?
-- [x] #include
-- [ ] import
-- [ ] using
+### What keyword is used to include a library in your sketch?
+1. [x] #include
+    > `#include` tells the preprocessor to pull in a header file.
+1. [ ] import
+1. [ ] using
+
+### Where do you typically install new libraries from inside the Arduino IDE?
+> This tool lets you search online packages.
+1. [x] Library Manager
+    > The Library Manager downloads and installs libraries.
+1. [ ] Serial Monitor
+1. [ ] Board Manager

--- a/docs/quizzes/loops_quiz.md
+++ b/docs/quizzes/loops_quiz.md
@@ -1,4 +1,14 @@
-# Which loop is best for iterating a known number of times?
-- [x] for loop
-- [ ] while loop
-- [ ] loop()
+### Which loop is best for iterating a known number of times?
+> Use this loop when you know exactly how many iterations you need.
+1. [x] for loop
+    > Correct. `for` loops handle a fixed count.
+1. [ ] while loop
+1. [ ] loop()
+    > `loop()` is the main Arduino function, not a counting loop.
+
+### Which statement stops a loop immediately?
+> Think about prematurely ending the loop.
+1. [ ] continue
+1. [x] break
+    > `break` exits the loop immediately.
+1. [ ] next

--- a/docs/quizzes/loops_quiz.md
+++ b/docs/quizzes/loops_quiz.md
@@ -1,0 +1,4 @@
+# Which loop is best for iterating a known number of times?
+- [x] for loop
+- [ ] while loop
+- [ ] loop()

--- a/docs/quizzes/loops_quiz.md
+++ b/docs/quizzes/loops_quiz.md
@@ -12,3 +12,16 @@
 1. [x] break
     > `break` exits the loop immediately.
 1. [ ] next
+
+### What numbers does this loop print?
+```cpp
+for (int i = 1; i <= 3; i++) {
+    Serial.println(i);
+}
+```
+> Look at the starting value and end condition.
+1. [x] 1 2 3
+    > The loop begins at 1 and stops after printing 3.
+1. [ ] 0 1 2
+1. [ ] 0 1 2 3
+1. [ ] 2 3 4

--- a/docs/quizzes/math_quiz.md
+++ b/docs/quizzes/math_quiz.md
@@ -1,4 +1,12 @@
-# Which operator returns the remainder of a division?
-- [ ] /
-- [ ] *
-- [x] %
+### Which operator returns the remainder of a division?
+> Think of modulo arithmetic.
+1. [ ] /
+1. [ ] *
+1. [x] %
+    > `%` gives the remainder.
+
+### What is the result of `2 * 3 + 1`?
+1. [ ] 5
+1. [x] 7
+    > Multiplication happens before addition.
+1. [ ] 9

--- a/docs/quizzes/math_quiz.md
+++ b/docs/quizzes/math_quiz.md
@@ -1,0 +1,4 @@
+# Which operator returns the remainder of a division?
+- [ ] /
+- [ ] *
+- [x] %

--- a/docs/quizzes/math_quiz.md
+++ b/docs/quizzes/math_quiz.md
@@ -10,3 +10,9 @@
 1. [x] 7
     > Multiplication happens before addition.
 1. [ ] 9
+
+### What does `Serial.println(4 / 2 + 1);` output?
+1. [ ] 2
+1. [x] 3
+    > Division happens before addition: 4 / 2 = 2, then +1 makes 3.
+1. [ ] 5

--- a/docs/quizzes/second_program_quiz.md
+++ b/docs/quizzes/second_program_quiz.md
@@ -9,3 +9,16 @@
     > `++` increases the value by one.
 1. [ ] +=2
 1. [ ] --
+
+### What value does `x` hold after this code runs?
+```cpp
+int x = 0;
+x++;
+x++;
+Serial.println(x);
+```
+> Each `++` adds one.
+1. [x] 2
+    > `x` is incremented twice before being printed.
+1. [ ] 1
+1. [ ] 0

--- a/docs/quizzes/second_program_quiz.md
+++ b/docs/quizzes/second_program_quiz.md
@@ -1,4 +1,11 @@
-# Which function continuously repeats during program execution?
-- [ ] setup()
-- [x] loop()
-- [ ] start()
+### Which function continuously repeats during program execution?
+1. [ ] setup()
+1. [x] loop()
+    > `loop()` runs over and over after setup completes.
+1. [ ] start()
+
+### Which operator increments a variable by one?
+1. [x] ++
+    > `++` increases the value by one.
+1. [ ] +=2
+1. [ ] --

--- a/docs/quizzes/second_program_quiz.md
+++ b/docs/quizzes/second_program_quiz.md
@@ -1,0 +1,4 @@
+# Which function continuously repeats during program execution?
+- [ ] setup()
+- [x] loop()
+- [ ] start()

--- a/docs/quizzes/variables_quiz.md
+++ b/docs/quizzes/variables_quiz.md
@@ -4,6 +4,14 @@
     > Use `const` to make a variable read-only.
 1. [ ] static
 
+### How do you declare an integer variable named `count` with an initial value of 0?
+> Variables use the format `<type> <name> = <value>;`.
+1. [x] int count = 0;
+    > Correct. This declares and initializes `count`.
+1. [ ] int = 0; count
+1. [ ] count int = 0;
+1. [ ] int count;
+
 ### Which data type is best for storing decimal numbers?
 1. [x] float
     > `float` holds values with fractional parts.

--- a/docs/quizzes/variables_quiz.md
+++ b/docs/quizzes/variables_quiz.md
@@ -1,0 +1,4 @@
+# Which keyword defines a constant variable?
+- [ ] var
+- [x] const
+- [ ] static

--- a/docs/quizzes/variables_quiz.md
+++ b/docs/quizzes/variables_quiz.md
@@ -1,4 +1,11 @@
-# Which keyword defines a constant variable?
-- [ ] var
-- [x] const
-- [ ] static
+### Which keyword defines a constant variable?
+1. [ ] var
+1. [x] const
+    > Use `const` to make a variable read-only.
+1. [ ] static
+
+### Which data type is best for storing decimal numbers?
+1. [x] float
+    > `float` holds values with fractional parts.
+1. [ ] int
+1. [ ] char

--- a/docs/second_arduino_program.rst
+++ b/docs/second_arduino_program.rst
@@ -120,3 +120,6 @@ Here's the updated code:
    Note that the comments from the original code have been removed so you
    can see what was easily updated. You can keep the comments in your code
    to help you understand what each part does, if you wish.
+
+.. quizdown:: quizzes/second_program_quiz.md
+

--- a/docs/variables.rst
+++ b/docs/variables.rst
@@ -437,8 +437,11 @@ you want to control the built-in LED without specifying a pin number.
    interacting with external components in the :ref:`Your First
    Arduino Program <first_arduino_program>` section.
 
-   These variables will be used extensively in your Arduino projects. Don't
-   worry about memorizing them now; you'll become familiar with them over time.
+
+    These variables will be used extensively in your Arduino projects. Don't
+    worry about memorizing them now; you'll become familiar with them over time.
+
+.. quizdown:: quizzes/variables_quiz.md
 
 .. _variable_scope:
 
@@ -578,4 +581,3 @@ efficient, and less error-prone programs. Aim to use global variables
 sparingly and rely on local variables whenever possible for modular,
 maintainable code.
 
-.. quizdown:: quizzes/variables_quiz.md

--- a/docs/variables.rst
+++ b/docs/variables.rst
@@ -577,3 +577,5 @@ By carefully managing variable scope, you can write cleaner, more
 efficient, and less error-prone programs. Aim to use global variables
 sparingly and rely on local variables whenever possible for modular,
 maintainable code.
+
+.. quizdown:: quizzes/variables_quiz.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 furo
+git+https://github.com/bonartm/sphinxcontrib-quizdown


### PR DESCRIPTION
## Summary
- enable `sphinxcontrib.quizdown` extension with global options
- store quizzes in dedicated markdown files and embed them without headings
- add quizdown dependency to `requirements.txt` using `git+https`
